### PR TITLE
Add landing page and download widget for WP Store

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WP Store – Плагин магазина WordPress</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>WP Store</h1>
+    <p>Простой и мощный плагин WordPress, помогающий быстро создать стильный и функциональный магазин.</p>
+    <a id="download-link" class="btn" href="#">Загрузка...</a>
+  </header>
+  <section>
+    <h2>Что умеет WP Store</h2>
+    <ul class="features">
+      <li>Лёгкая интеграция с вашим сайтом.</li>
+      <li>Гибкие настройки товаров и категорий.</li>
+      <li>Автоматические обновления и поддержка.</li>
+    </ul>
+  </section>
+  <footer>
+    <p>Проект с открытым исходным кодом на <a href="https://github.com/ilterracom/wp-store" target="_blank" rel="noopener">GitHub</a>.</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,27 +1,28 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>WP Store – Плагин магазина WordPress</title>
+  <title>WP Store – Ilterra's Plugin Manager for WordPress</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
     <h1>WP Store</h1>
-    <p>Простой и мощный плагин WordPress, помогающий быстро создать стильный и функциональный магазин.</p>
-    <a id="download-link" class="btn" href="#">Загрузка...</a>
+    <p>WP Store is an independent plugin manager that lets you install and update Ilterra's proprietary WordPress plugins without relying on the official repository.</p>
+    <a id="download-link" class="btn" href="#">Loading…</a>
   </header>
   <section>
-    <h2>Что умеет WP Store</h2>
+    <h2>Why WP Store?</h2>
     <ul class="features">
-      <li>Лёгкая интеграция с вашим сайтом.</li>
-      <li>Гибкие настройки товаров и категорий.</li>
-      <li>Автоматические обновления и поддержка.</li>
+      <li>Install and update Ilterra plugins directly.</li>
+      <li>Streamlined releases without external review queues.</li>
+      <li>Secure distribution for closed-source plugins.</li>
     </ul>
   </section>
   <footer>
-    <p>Проект с открытым исходным кодом на <a href="https://github.com/ilterracom/wp-store" target="_blank" rel="noopener">GitHub</a>.</p>
+    <p><a href="https://github.com/ilterracom/wp-store" target="_blank" rel="noopener">Project on GitHub</a></p>
+    <p>Created by Yauhen Panimatchanka at <a href="https://ilterra.com" target="_blank" rel="noopener">Ilterra</a>.</p>
   </footer>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -8,10 +8,10 @@ async function updateDownloadLink() {
       const url = `https://github.com/ilterracom/wp-store/archive/refs/tags/${tag}.zip`;
       const btn = document.getElementById('download-link');
       btn.href = url;
-      btn.textContent = `Скачать ${tag}`;
+      btn.textContent = `Download ${tag}`;
     }
   } catch (err) {
-    console.error('Не удалось получить последнюю версию плагина', err);
+    console.error('Failed to retrieve the latest plugin version', err);
   }
 }
 

--- a/script.js
+++ b/script.js
@@ -1,0 +1,18 @@
+async function updateDownloadLink() {
+  try {
+    const response = await fetch('https://api.github.com/repos/ilterracom/wp-store/git/matching-refs/tags/wp-store/');
+    const tags = await response.json();
+    if (Array.isArray(tags) && tags.length) {
+      const latest = tags.sort((a, b) => a.ref.localeCompare(b.ref)).pop();
+      const tag = latest.ref.replace('refs/tags/', '');
+      const url = `https://github.com/ilterracom/wp-store/archive/refs/tags/${tag}.zip`;
+      const btn = document.getElementById('download-link');
+      btn.href = url;
+      btn.textContent = `Скачать ${tag}`;
+    }
+  } catch (err) {
+    console.error('Не удалось получить последнюю версию плагина', err);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', updateDownloadLink);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,65 @@
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(135deg, #4b6cb7 0%, #182848 100%);
+  color: #fff;
+  text-align: center;
+}
+header {
+  padding: 60px 20px;
+}
+header h1 {
+  font-size: 3em;
+  margin-bottom: 0.3em;
+}
+header p {
+  font-size: 1.2em;
+  max-width: 600px;
+  margin: 0 auto;
+}
+.btn {
+  display: inline-block;
+  margin-top: 30px;
+  padding: 15px 30px;
+  background: #ff5722;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: bold;
+  transition: background 0.3s;
+}
+.btn:hover {
+  background: #e64a19;
+}
+section {
+  background: #fff;
+  color: #333;
+  padding: 40px 20px;
+}
+section h2 {
+  margin-top: 0;
+}
+.features {
+  list-style: none;
+  padding: 0;
+  max-width: 600px;
+  margin: 20px auto;
+  text-align: left;
+}
+.features li {
+  margin-bottom: 10px;
+  padding-left: 20px;
+  position: relative;
+}
+.features li:before {
+  content: '\2713';
+  position: absolute;
+  left: 0;
+  color: #4b6cb7;
+}
+footer {
+  margin-top: 40px;
+  padding: 20px;
+  font-size: 0.9em;
+  opacity: 0.8;
+}

--- a/widget.html
+++ b/widget.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Виджет загрузки WP Store</title>
+  <title>WP Store Download Widget</title>
 </head>
 <body>
-  <!-- Этот код можно встроить на любую страницу -->
+  <!-- Embed this snippet on any page -->
   <div id="wp-store-widget">
-    <a id="wp-store-widget-btn" href="#" style="display:inline-block;padding:10px 20px;background:#4b6cb7;color:#fff;border-radius:4px;text-decoration:none;">Скачать WP Store</a>
+    <a id="wp-store-widget-btn" href="#" style="display:inline-block;padding:10px 20px;background:#4b6cb7;color:#fff;border-radius:4px;text-decoration:none;">Download WP Store</a>
   </div>
   <script>
     async function updateWpStoreWidget() {
@@ -20,10 +20,10 @@
           const url = `https://github.com/ilterracom/wp-store/archive/refs/tags/${tag}.zip`;
           const btn = document.getElementById('wp-store-widget-btn');
           btn.href = url;
-          btn.textContent = `Скачать WP Store ${tag}`;
+          btn.textContent = `Download WP Store ${tag}`;
         }
       } catch (e) {
-        console.error('Не удалось обновить ссылку', e);
+        console.error('Failed to update link', e);
       }
     }
     updateWpStoreWidget();

--- a/widget.html
+++ b/widget.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Виджет загрузки WP Store</title>
+</head>
+<body>
+  <!-- Этот код можно встроить на любую страницу -->
+  <div id="wp-store-widget">
+    <a id="wp-store-widget-btn" href="#" style="display:inline-block;padding:10px 20px;background:#4b6cb7;color:#fff;border-radius:4px;text-decoration:none;">Скачать WP Store</a>
+  </div>
+  <script>
+    async function updateWpStoreWidget() {
+      try {
+        const res = await fetch('https://api.github.com/repos/ilterracom/wp-store/git/matching-refs/tags/wp-store/');
+        const tags = await res.json();
+        if (Array.isArray(tags) && tags.length) {
+          const latest = tags.sort((a,b) => a.ref.localeCompare(b.ref)).pop();
+          const tag = latest.ref.replace('refs/tags/','');
+          const url = `https://github.com/ilterracom/wp-store/archive/refs/tags/${tag}.zip`;
+          const btn = document.getElementById('wp-store-widget-btn');
+          btn.href = url;
+          btn.textContent = `Скачать WP Store ${tag}`;
+        }
+      } catch (e) {
+        console.error('Не удалось обновить ссылку', e);
+      }
+    }
+    updateWpStoreWidget();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a single-page landing site introducing WP Store and linking to the latest plugin version
- add styling and script files for attractive design and dynamic download link
- include standalone widget snippet for embedding a download button elsewhere

## Testing
- `php -l wp-store.php`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bff3224f48832c88420b6b48a17610